### PR TITLE
Mark 'durable.worker.execute_task' span as an OTEL 'server' span

### DIFF
--- a/src/worker.rs
+++ b/src/worker.rs
@@ -285,6 +285,8 @@ impl Worker {
             run_id = %task.run_id,
             task_name = %task.task_name,
             attempt = task.attempt,
+            // This makes things render nicely on AWS X-Ray when propagating trace contexts.
+            otel.kind = "server",
         );
 
         // Extract and set parent trace context from headers (for distributed tracing)


### PR DESCRIPTION
This create a new 'segment' in AWS X-ray, which makes the task execution show up as a distinct service, rather than being directly included in the parent as a subsegment