### PR TITLE
Revert "Create an OpenTelemetry link instead of setting parent (#53)"

### DIFF
--- a/src/worker.rs
+++ b/src/worker.rs
@@ -289,16 +289,14 @@ impl Worker {
             otel.kind = "server",
         );
 
-        // Extract and add a trace link to the context from headers (for distributed tracing)
-        // We don't set the parent, since a task can be executed multiple times
-        // long after the original span from headers (e.g. an autopilot-api HTTP request)
-        // finishes.
+        // Extract and set parent trace context from headers (for distributed tracing)
         #[cfg(feature = "telemetry")]
         if let Some(ref headers) = task.headers {
-            use opentelemetry::trace::TraceContextExt;
             use tracing_opentelemetry::OpenTelemetrySpanExt;
             let parent_cx = crate::telemetry::extract_trace_context(headers);
-            span.add_link(parent_cx.span().span_context().clone());
+            if let Err(e) = span.set_parent(parent_cx) {
+                tracing::error!("Failed to update OpenTelemetry span {e:?}");
+            }
         }
 
         Self::execute_task_inner(


### PR DESCRIPTION
Sentry and AWS X-ray don't handle links properly, so let's switch back to setting the parent for now