### PR TITLE
Lower 'durable.worker.claim_tasks' span to 'debug' level

### DIFF
--- a/src/worker.rs
+++ b/src/worker.rs
@@ -220,6 +220,7 @@ impl Worker {
     #[cfg_attr(
         feature = "telemetry",
         tracing::instrument(
+            level = "debug",
             name = "durable.worker.claim_tasks",
             skip(pool),
             fields(queue = %queue_name, worker_id = %worker_id, count = count)


### PR DESCRIPTION
We already have the metric, so let's avoid reporting lots of spans to OpenTelemetry