### PR TITLE
add a migration adding an index for claim task 

### DIFF
--- a/sql/schema.sql
+++ b/sql/schema.sql
@@ -213,18 +213,12 @@ begin
     't_' || p_queue_name
   );
 
+  -- Composite index for active task state lookups.
+  -- Enables Index Only Scans for claim_task join, emit_event, and cancel propagation.
   execute format(
-    'create index if not exists %I on durable.%I (task_id)
-     where state = ''cancelled''',
-    ('t_' || p_queue_name) || '_cxl',
-    't_' || p_queue_name
-  );
-
-  -- Speed up emit_event sleeping task lookup.
-  execute format(
-    'create index if not exists %I on durable.%I (task_id)
-     where state = ''sleeping''',
-    ('t_' || p_queue_name) || '_slp',
+    'create index if not exists %I on durable.%I (state, task_id)
+     where state in (''pending'', ''sleeping'', ''running'', ''cancelled'')',
+    ('t_' || p_queue_name) || '_state_tid',
     't_' || p_queue_name
   );
 end;

--- a/src/postgres/migrations/20251205000000_add_claim_task_indexes.sql
+++ b/src/postgres/migrations/20251205000000_add_claim_task_indexes.sql
@@ -155,18 +155,12 @@ begin
     't_' || p_queue_name
   );
 
+  -- Composite index for active task state lookups.
+  -- Enables Index Only Scans for claim_task join, emit_event, and cancel propagation.
   execute format(
-    'create index if not exists %I on durable.%I (task_id)
-     where state = ''cancelled''',
-    ('t_' || p_queue_name) || '_cxl',
-    't_' || p_queue_name
-  );
-
-  -- Speed up emit_event sleeping task lookup.
-  execute format(
-    'create index if not exists %I on durable.%I (task_id)
-     where state = ''sleeping''',
-    ('t_' || p_queue_name) || '_slp',
+    'create index if not exists %I on durable.%I (state, task_id)
+     where state in (''pending'', ''sleeping'', ''running'', ''cancelled'')',
+    ('t_' || p_queue_name) || '_state_tid',
     't_' || p_queue_name
   );
 end;


### PR DESCRIPTION
Also added infra for nicer migrations

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Improves `claim_task` performance and adds a migration to roll out new indexes across existing queues.
> 
> - Adds targeted indexes in `ensure_queue_tables`: `r_*_ready` partial index on `(available_at, run_id) include (task_id)`, `w_*_ti` on `task_id`, `r_*_cei` partial index on `claim_expires_at` for running runs, `t_*_cxlpol` partial index on `task_id` for tasks with cancellation policies, and `t_*_state_tid` composite index on `(state, task_id)`
> - Updates `claim_task` to only scan tasks that have cancellation policies when applying max_delay/max_duration cancellations
> - Introduces migration `20251205000000_add_claim_task_indexes.sql` to `CREATE OR REPLACE` affected functions and apply indexes to existing queues via a DO block
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0eee55a92a6bcfb5185374b910d07a6fff1be8ec. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->