### PR TITLE
Add 'cached' field to durable.task.step span

### DIFF
--- a/src/context.rs
+++ b/src/context.rs
@@ -180,13 +180,16 @@ where
         validate_user_name(base_name)?;
         let checkpoint_name = self.get_checkpoint_name(base_name, &params)?;
 
+        #[cfg(feature = "telemetry")]
         let span = tracing::Span::current();
 
         // Return cached value if step was already completed
         if let Some(cached) = self.checkpoint_cache.get(&checkpoint_name) {
+            #[cfg(feature = "telemetry")]
             span.record("cached", true);
             return Ok(serde_json::from_value(cached.clone())?);
         }
+        #[cfg(feature = "telemetry")]
         span.record("cached", false);
 
         // Execute the step


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk: telemetry-only change that adds a span field and records whether `step()` returned a cached checkpoint result. No changes to step execution, checkpointing, or data persistence logic.
> 
> **Overview**
> Adds a new `cached` field to the `durable.task.step` `tracing::instrument` span and records it at runtime as `true` when a checkpointed step returns a cached value and `false` otherwise.
> 
> This is gated behind the `telemetry` feature and does not alter step behavior beyond additional span metadata.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f39a22679a41ef45fb09d7300ec9462683c659b2. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->